### PR TITLE
Add support for describeMetric types

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -77,8 +77,13 @@ func (c *Client) ListMetrics(types []MetricType) ([]ListMetricsResult, error) {
 	return results, nil
 }
 
+type AttributeDesc struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 type DescribeMetricResult struct {
-	Attributes []string `json:"attributes"`
+	Attributes []AttributeDesc `json:"attributes"`
 }
 
 func (c *Client) DescribeMetric(metric string) (*DescribeMetricResult, error) {


### PR DESCRIPTION
Adds support for the new type metadata in describeMetric responses introduced in https://github.com/HarperDB/harperdb/pull/2675